### PR TITLE
Add custom malware feed

### DIFF
--- a/internal/api/feed/malware.go
+++ b/internal/api/feed/malware.go
@@ -1,0 +1,35 @@
+package feed
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/api"
+)
+
+const CustomMalwareEndpoint = "api/v1/feeds/custom/malware"
+
+type CustomMalware struct {
+	Feed []CustomMalwareFeedItem `json:"feed,omitempty"`
+}
+
+type CustomMalwareFeedItem struct {
+	MD5      string `json:"md5,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Modified int    `json:"modified,omitempty"`
+	Allowed  bool   `json:"allowed,omitempty"`
+}
+
+// Get the current custom malware feed.
+func GetCustomMalware(c api.Client) (CustomMalware, error) {
+	var ans CustomMalware
+	if err := c.Request(http.MethodGet, CustomMalwareEndpoint, nil, nil, &ans); err != nil {
+		return ans, fmt.Errorf("error getting custom malware: %s", err)
+	}
+	return ans, nil
+}
+
+// Update the current custom malware feed.
+func UpdateCustomMalware(c api.Client, malware CustomMalware) error {
+	return c.Request(http.MethodPut, CustomMalwareEndpoint, nil, malware, nil)
+}

--- a/internal/convert/custom_malware.go
+++ b/internal/convert/custom_malware.go
@@ -1,0 +1,38 @@
+package convert
+
+import (
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/api/feed"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func SchemaToCustomMalwareFeed(d *schema.ResourceData) ([]feed.CustomMalwareFeedItem, error) {
+	parsedMalwareFeed := make([]feed.CustomMalwareFeedItem, 0)
+	if malwareFeed, ok := d.GetOk("feed"); ok {
+		presentFeed := malwareFeed.([]interface{})
+		for _, val := range presentFeed {
+			presentFeedItem := val.(map[string]interface{})
+			parsedFeedItem := feed.CustomMalwareFeedItem{}
+
+			parsedFeedItem.Name = presentFeedItem["name"].(string)
+			parsedFeedItem.MD5 = presentFeedItem["md5"].(string)
+			parsedFeedItem.Modified = presentFeedItem["modified"].(int)
+			parsedFeedItem.Allowed = presentFeedItem["allowed"].(bool)
+
+			parsedMalwareFeed = append(parsedMalwareFeed, parsedFeedItem)
+		}
+	}
+	return parsedMalwareFeed, nil
+}
+
+func CustomMalwareFeedToSchema(in []feed.CustomMalwareFeedItem) []interface{} {
+	ans := make([]interface{}, 0, len(in))
+	for _, val := range in {
+		m := make(map[string]interface{})
+		m["name"] = val.Name
+		m["md5"] = val.MD5
+		m["modified"] = val.Modified
+		m["allowed"] = val.Allowed
+		ans = append(ans, m)
+	}
+	return ans
+}

--- a/internal/provider/common.go
+++ b/internal/provider/common.go
@@ -14,4 +14,5 @@ const (
 	policyTypeVulnerabilityCoderepo   = "codeRepoVulnerability"
 	policyTypeVulnerabilityHost       = "hostVulnerability"
 	policyTypeVulnerabilityImage      = "containerVulnerability"
+	feedTypeCustomMalware             = "customMalware"
 )

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -75,6 +75,7 @@ func Provider() *schema.Provider {
 			"prismacloudcompute_role":                             resourceRbacRoles(),
 			"prismacloudcompute_credential":                       resourceCredentials(),
 			"prismacloudcompute_custom_compliance":                resourceCustomCompliance(),
+			"prismacloudcompute_custom_malware":                   resourceCustomMalwareFeed(),
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/internal/provider/resource_custom_malware_feed.go
+++ b/internal/provider/resource_custom_malware_feed.go
@@ -1,0 +1,120 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/api"
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/api/feed"
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/convert"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceCustomMalwareFeed() *schema.Resource {
+	return &schema.Resource{
+		Create: createCustomMalwareFeed,
+		Read:   readCustomMalwareFeed,
+		Update: updateCustomMalwareFeed,
+		Delete: deleteCustomMalwareFeed,
+
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the custom malware feed.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+			"feed": {
+				Type:        schema.TypeList,
+				Optional:    true,
+				Description: "Feed items list.",
+				MinItems:    1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"md5": {
+							Type:        schema.TypeString,
+							Optional:    false,
+							Required:    true,
+							Description: "MD5 hash for the malware.",
+						},
+						"name": {
+							Type:        schema.TypeString,
+							Optional:    false,
+							Required:    true,
+							Description: "Name for the item.",
+						},
+						"modified": {
+							Type:        schema.TypeInt,
+							Optional:    true,
+							Description: "Modified toggle.",
+							Default:     0,
+						},
+						"allowed": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Description: "Allowed toggle.",
+							Default:     true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func createCustomMalwareFeed(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	parsedCustomMalwareFeed, err := convert.SchemaToCustomMalwareFeed(d)
+
+	if err != nil {
+		return fmt.Errorf("error creating custom malware feed '%+v': %s", parsedCustomMalwareFeed, err)
+	}
+	parsedFeed := feed.CustomMalware{
+		Feed: parsedCustomMalwareFeed,
+	}
+
+	if err := feed.UpdateCustomMalware(*client, parsedFeed); err != nil {
+		return fmt.Errorf("error creating %s custom malware feed: %s", feedTypeCustomMalware, err)
+	}
+
+	d.SetId(feedTypeCustomMalware)
+	return readCustomMalwareFeed(d, meta)
+}
+
+func readCustomMalwareFeed(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	retrievedCustomMalware, err := feed.GetCustomMalware(*client)
+	if err != nil {
+		return fmt.Errorf("error reading %s custom malware feed: %s", feedTypeCustomMalware, err)
+	}
+
+	if err := d.Set("feed", convert.CustomMalwareFeedToSchema(retrievedCustomMalware.Feed)); err != nil {
+		return fmt.Errorf("error reading %s custom malware feed: %s", feedTypeCustomMalware, err)
+	}
+
+	return nil
+}
+
+func updateCustomMalwareFeed(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*api.Client)
+	parsedCustomMalwareFeed, err := convert.SchemaToCustomMalwareFeed(d)
+	if err != nil {
+		return fmt.Errorf("error updating custom malware feed '%+v': %s", parsedCustomMalwareFeed, err)
+	}
+
+	parsedFeed := feed.CustomMalware{
+		Feed: parsedCustomMalwareFeed,
+	}
+	if err := feed.UpdateCustomMalware(*client, parsedFeed); err != nil {
+		return fmt.Errorf("error updating custom malware feed '%+v': %s", parsedCustomMalwareFeed, err)
+	}
+
+	return readCustomMalwareFeed(d, meta)
+}
+
+func deleteCustomMalwareFeed(d *schema.ResourceData, meta interface{}) error {
+	// TODO: reset to default policy
+	return nil
+}

--- a/internal/provider/resource_custom_malware_feed_test.go
+++ b/internal/provider/resource_custom_malware_feed_test.go
@@ -1,0 +1,78 @@
+package provider
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/api/feed"
+	"github.com/PaloAltoNetworks/terraform-provider-prismacloudcompute/internal/convert"
+)
+
+type customMalwareFeedItem struct {
+	md5      string
+	name     string
+	modified int
+	allowed  bool
+}
+
+func TestFlattenCustomMalwareFeed(t *testing.T) {
+	cases := []struct {
+		feed     []feed.CustomMalwareFeedItem
+		expected []customMalwareFeedItem
+	}{
+		{
+			feed: []feed.CustomMalwareFeedItem{
+				feed.CustomMalwareFeedItem{
+					Name:     "allowed",
+					MD5:      "22ee71e9dcc9ca12fc313c6e1ce3f806",
+					Modified: 0,
+					Allowed:  true,
+				},
+				feed.CustomMalwareFeedItem{
+					Name:     "denied",
+					MD5:      "865726b2885feef8e8b25b56a2d7c8f8",
+					Modified: 0,
+					Allowed:  false,
+				},
+			},
+			expected: []customMalwareFeedItem{
+				customMalwareFeedItem{
+					name:     "allowed",
+					md5:      "22ee71e9dcc9ca12fc313c6e1ce3f806",
+					modified: 0,
+					allowed:  true,
+				},
+				customMalwareFeedItem{
+					name:     "denied",
+					md5:      "865726b2885feef8e8b25b56a2d7c8f8",
+					modified: 0,
+					allowed:  false,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		out := convert.CustomMalwareFeedToSchema(c.feed)
+		allowed := out[0].(map[string]interface{})
+		if !reflect.DeepEqual(allowed["name"], c.expected[0].name) {
+			t.Fatalf("Error matching output and expected for allowed name: %#v vs %#v", out, c.expected)
+		}
+		if !reflect.DeepEqual(allowed["md5"], c.expected[0].md5) {
+			t.Fatalf("Error matching output and expected for allowed md5: %#v vs %#v", out, c.expected)
+		}
+		if !reflect.DeepEqual(allowed["allowed"], c.expected[0].allowed) {
+			t.Fatalf("Error matching output and expected for allowed allowed: %#v vs %#v", out, c.expected)
+		}
+		denied := out[1].(map[string]interface{})
+		if !reflect.DeepEqual(denied["name"], c.expected[1].name) {
+			t.Fatalf("Error matching output and expected for denied name: %#v vs %#v", out, c.expected)
+		}
+		if !reflect.DeepEqual(denied["md5"], c.expected[1].md5) {
+			t.Fatalf("Error matching output and expected for denied md5: %#v vs %#v", out, c.expected)
+		}
+		if !reflect.DeepEqual(denied["allowed"], c.expected[1].allowed) {
+			t.Fatalf("Error matching output and expected for denied allowed: %#v vs %#v", out, c.expected)
+		}
+	}
+}


### PR DESCRIPTION
Example of usage:

```hcl


resource "prismacloudcompute_custom_malware" "custom" {
  feed  {
    md5 = "044003f961de0e52bdd6e561460cb05a"
    name =  "allowed"
  }
  feed  {
    md5 = "1447a3f961de0e52b086e561460cb05a"
    name =  "denied"
    allowed = false
  }
}

```